### PR TITLE
fix: db migrations

### DIFF
--- a/frontend/dev-dist/sw.js
+++ b/frontend/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-9dc17825'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.49kc8gesui"
+    "revision": "0.d71oor8f0e4"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -91,7 +91,6 @@ const AdminDashboard: React.FC = () => {
   const [newSentence, setNewSentence] = useState({
     source_text: '',
     machine_translation: '',
-    tagalog_source_text: '',
     back_translation: '',
     source_language: 'en',
     target_language: 'tgl',
@@ -470,7 +469,6 @@ const AdminDashboard: React.FC = () => {
       setNewSentence({
         source_text: '',
         machine_translation: '',
-        tagalog_source_text: '',
         back_translation: '',
         source_language: 'en',
         target_language: 'tgl',
@@ -501,7 +499,6 @@ const AdminDashboard: React.FC = () => {
       await adminAPI.updateSentence(editingSentence.id, {
         source_text: editingSentence.source_text,
         machine_translation: editingSentence.machine_translation,
-        tagalog_source_text: editingSentence.tagalog_source_text,
         source_language: editingSentence.source_language,
         target_language: editingSentence.target_language,
         domain: editingSentence.domain,
@@ -2522,17 +2519,7 @@ const AdminDashboard: React.FC = () => {
                       />
                     </div>
 
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Tagalog Source Text (Optional)
-                      </label>
-                      <textarea
-                        value={editingSentence.tagalog_source_text || ''}
-                        onChange={(e) => setEditingSentence({...editingSentence, tagalog_source_text: e.target.value})}
-                        className="textarea-field autocomplete-off"
-                        placeholder="Enter the Tagalog source text if available..."
-                      />
-                    </div>
+
 
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -2789,15 +2776,7 @@ const AdminDashboard: React.FC = () => {
                                 <p className="text-base sm:text-sm text-gray-900 leading-relaxed">{sentence.source_text}</p>
                               </div>
 
-                              {/* Tagalog Source (if available) */}
-                              {sentence.tagalog_source_text && (
-                                <div className="bg-emerald-50 border-l-4 border-emerald-400 p-4 sm:p-3 rounded-r-lg">
-                                  <h5 className="text-xs font-medium text-emerald-900 mb-3 sm:mb-2 uppercase tracking-wide">
-                                    Tagalog Source Text
-                                  </h5>
-                                  <p className="text-base sm:text-sm text-gray-900 leading-relaxed">{sentence.tagalog_source_text}</p>
-                                </div>
-                              )}
+
 
                               {/* Machine Translation with Tags */}
                               <div className="bg-gradient-to-r from-purple-50 to-indigo-50 border-2 border-purple-200 rounded-lg p-4 sm:p-3">

--- a/frontend/src/services/supabase-api.ts
+++ b/frontend/src/services/supabase-api.ts
@@ -450,7 +450,6 @@ export const sentencesAPI = {
   createSentence: async (sentenceData: {
     source_text: string;
     machine_translation: string;
-    tagalog_source_text?: string;
     source_language: string;
     target_language: string;
     domain?: string;
@@ -460,7 +459,6 @@ export const sentencesAPI = {
       .insert({
         source_text: sentenceData.source_text,
         machine_translation: sentenceData.machine_translation,
-        tagalog_source_text: sentenceData.tagalog_source_text,
         source_language: sentenceData.source_language,
         target_language: sentenceData.target_language,
         domain: sentenceData.domain,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,7 +21,6 @@ export interface Sentence {
   source_text: string;
   machine_translation: string;
   reference_translation?: string;  // Reference/human translation for comparison
-  tagalog_source_text?: string;
   source_language: string;
   target_language: string;
   domain?: string;


### PR DESCRIPTION
This pull request removes support for the `tagalog_source_text` field from the frontend codebase. All references to this field have been deleted from the UI, API calls, and type definitions, simplifying sentence management and editing. The changes focus on cleaning up unused fields and related UI elements.

**Frontend cleanup:**

* Removed the `tagalog_source_text` field from the `Sentence` type definition in `frontend/src/types/index.ts`.
* Deleted all UI elements related to `tagalog_source_text` in the `AdminDashboard` component, including form inputs and display sections. [[1]](diffhunk://#diff-9e5f1e01fd2a74bee7e2d911d40451c91669140382f0740451137c5eac621920L94) [[2]](diffhunk://#diff-9e5f1e01fd2a74bee7e2d911d40451c91669140382f0740451137c5eac621920L473) [[3]](diffhunk://#diff-9e5f1e01fd2a74bee7e2d911d40451c91669140382f0740451137c5eac621920L2525-R2522) [[4]](diffhunk://#diff-9e5f1e01fd2a74bee7e2d911d40451c91669140382f0740451137c5eac621920L2792-R2779) [[5]](diffhunk://#diff-9e5f1e01fd2a74bee7e2d911d40451c91669140382f0740451137c5eac621920L504)

**API changes:**

* Removed `tagalog_source_text` from the sentence creation API in `frontend/src/services/supabase-api.ts`, both from the parameter list and the database insertion logic. [[1]](diffhunk://#diff-9f24d5d59bf7e20568659451abad52c4d8bc2a2a510d3a2ea599ce77b152d5f7L453) [[2]](diffhunk://#diff-9f24d5d59bf7e20568659451abad52c4d8bc2a2a510d3a2ea599ce77b152d5f7L463)

**Build artifact update:**

* Updated the revision hash for `index.html` in the service worker cache manifest in `frontend/dev-dist/sw.js` to reflect the new build.